### PR TITLE
Correctly order decls in `ReplaceDecl`.

### DIFF
--- a/src/replaceDecl.ml
+++ b/src/replaceDecl.ml
@@ -44,7 +44,7 @@ let fold_decls v state decls =
          | Prepend prepend ->
              (Keep, user_state), decl :: List.rev prepend @ decls
          | Append append ->
-             (Keep, user_state), decls @ List.rev append @ [decl]
+             (Keep, user_state), List.rev append @ [decl] @ decls
       ) (state, []) decls
   in
   assert (fst state = Keep);

--- a/src/tests/replaceDecl.api.h
+++ b/src/tests/replaceDecl.api.h
@@ -1,0 +1,12 @@
+class foo {
+  uint8_t bar();
+
+  /**
+   * Moop.
+   */
+  struct this [get, set] {
+    uint8_t order;
+  }
+
+  uint8_t cow();
+}

--- a/src/tests/replaceDecl.exp.h
+++ b/src/tests/replaceDecl.exp.h
@@ -1,0 +1,18 @@
+
+uint8_t foo_bar(Foo *foo);
+
+/**
+ * Moop.
+ */
+struct Foo {
+
+  uint8_t order;
+  
+};
+
+
+uint8_t foo_get_order(const Foo *foo);
+
+void foo_set_order(Foo *foo, uint8_t order);
+
+uint8_t foo_cow(Foo *foo);


### PR DESCRIPTION
It used to reorder declarations in an `append` operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/apidsl/15)
<!-- Reviewable:end -->
